### PR TITLE
TOA-72

### DIFF
--- a/nvx-hornet/src/main/java/com/neeve/managed/annotations/Managed.java
+++ b/nvx-hornet/src/main/java/com/neeve/managed/annotations/Managed.java
@@ -25,6 +25,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
 import javax.inject.Qualifier;
 
 import com.neeve.aep.annotations.EventHandler;

--- a/nvx-hornet/src/main/java/com/neeve/toa/DefaultManagedObjectLocator.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/DefaultManagedObjectLocator.java
@@ -9,9 +9,9 @@
  *
  * Neeve Research licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at:
+ * with the License. You may obtain a copy of the License at:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -57,6 +57,7 @@ public class DefaultManagedObjectLocator extends AbstractManagedObjectLocator {
         app.addAppStatContainers(managedObjects);
         app.addChannelFilterProviders(managedObjects);
         app.addChannelQosProviders(managedObjects);
+        app.addChannelJoinProviders(managedObjects);
         app.addChannelInitialKeyResolutionTableProviders(managedObjects);
         app.addTopicResolverProviders(managedObjects);
     }

--- a/nvx-hornet/src/main/java/com/neeve/toa/GeneratedTopicResolverProvider.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/GeneratedTopicResolverProvider.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
-import com.neeve.util.UtlText;
 import com.neeve.managed.ManagedObjectLocator;
 import com.neeve.root.RootConfig;
 import com.neeve.toa.service.ToaService;
@@ -34,6 +33,7 @@ import com.neeve.toa.spi.TopicResolver;
 import com.neeve.toa.spi.TopicResolverProvider;
 import com.neeve.toa.tools.ToaCodeGenerator;
 import com.neeve.trace.Tracer;
+import com.neeve.util.UtlText;
 
 /**
  * This {@link TopicResolverProvider} attempts to load {@link ToaCodeGenerator} generated {@link TopicResolverProvider}s.

--- a/nvx-hornet/src/main/java/com/neeve/toa/service/ToaService.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/service/ToaService.java
@@ -9,9 +9,9 @@
  *
  * Neeve Research licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at:
+ * with the License. You may obtain a copy of the License at:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -480,4 +480,10 @@ public class ToaService {
         return messageChannel;
     }
 
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    public String toString() {
+        return "ToaService [name=" + getName() + " prefixChannelNames=" + isPrefixChannelNames() + "]";
+    }
 }

--- a/nvx-hornet/src/main/java/com/neeve/toa/service/ToaServiceChannel.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/service/ToaServiceChannel.java
@@ -9,9 +9,9 @@
  *
  * Neeve Research licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at:
+ * with the License. You may obtain a copy of the License at:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -176,5 +176,12 @@ public class ToaServiceChannel {
      */
     public String getInitiallyResolvedKey() {
         return resolvedKey;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    public String toString() {
+        return "ToaServiceChannel [name=" + getName() + ", bus=" + getBusName() + ", key=" + getKey() + ", service=" + (service != null ? service : "null") + "]";
     }
 }

--- a/nvx-hornet/src/main/java/com/neeve/toa/spi/ChannelJoinProvider.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/spi/ChannelJoinProvider.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2016 Neeve Research, LLC
+ *
+ * This product includes software developed at Neeve Research, LLC
+ * (http://www.neeveresearch.com/) as well as software licenced to
+ * Neeve Research, LLC under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * Neeve Research licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.neeve.toa.spi;
+
+import com.neeve.aep.annotations.EventHandler;
+import com.neeve.toa.TopicOrientedApplication;
+import com.neeve.toa.TopicOrientedApplication.ChannelJoin;
+import com.neeve.toa.service.ToaService;
+import com.neeve.toa.service.ToaServiceChannel;
+
+/**
+ * A {@link ChannelJoinProvider} can be used to specify the whether or not a channel should be joined. 
+ * <p>
+ * Normally a {@link TopicOrientedApplication} will automatically join a channel if it
+ * finds an {@link EventHandler} for a message type that is mapped to the channel in a 
+ * service definition. An application may provide a {@link ChannelJoinProvider} to override 
+ * this behavior. 
+ */
+public interface ChannelJoinProvider {
+
+    /**
+     * Indicates whether or not a channel should be joined. 
+     * <h2>Return Values</h2>
+     * A {@link ChannelJoinProvider} may return a {@link ChannelJoin} value
+     * to indicate whether or not a channel should be joined:
+     * <ul> A value of {@link ChannelJoin#Default Default} or <code>null</code> indicates
+     * that the provider has no opinion and will defer to the default behavior of Hornet
+     * or other {@link ChannelJoinProvider}s
+     * <li> A value of {@link ChannelJoin#Join Join} indicates that the the channel should
+     * be joined even if there is no {@link EventHandler} handler registered for any of the
+     * channel's types. <i>Overriding the default behavior to join a channel should be rare,
+     * since applications should not be attracting messages without handlers or sending 
+     * messages on channels other than those that they are mapped to in a service definition.</i>
+     * <li>  {@link ChannelJoin#NoJoin NoJoin} indicates that even if there is a message handler
+     * defined for a type mapped to the channel, that the channel should not be joined.
+     * </ul>
+     * 
+     * <h2>ChannelJoinProvider Conflicts</h2>
+     * It is illegal for one {@link ChannelJoinProvider} returns {@link ChannelJoin#Join Join} 
+     * and another to return {@link ChannelJoin#NoJoin NoJoin}. The application will fail to 
+     * start in such a case. 
+     * 
+     * @param service The service that defined the channel.
+     * @param channel The channel. 
+     * 
+     * @return A value indicating whether or not the channel should be joined. 
+     */
+    public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel);
+}

--- a/nvx-hornet/src/main/java/com/neeve/toa/spi/TopicResolver.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/spi/TopicResolver.java
@@ -24,8 +24,8 @@ package com.neeve.toa.spi;
 import java.util.Properties;
 
 import com.neeve.lang.XString;
-import com.neeve.sma.MessageView;
 import com.neeve.sma.MessageChannel.RawKeyResolutionTable;
+import com.neeve.sma.MessageView;
 import com.neeve.toa.TopicOrientedApplication;
 import com.neeve.toa.service.ToaServiceChannel;
 

--- a/nvx-hornet/src/test/java/com/neeve/toa/test/unit/ChannelResolutionTest.java
+++ b/nvx-hornet/src/test/java/com/neeve/toa/test/unit/ChannelResolutionTest.java
@@ -40,9 +40,9 @@ import com.neeve.lang.XString;
 import com.neeve.rog.IRogMessage;
 import com.neeve.server.app.annotations.AppHAPolicy;
 import com.neeve.sma.MessageBusBindingFactory;
+import com.neeve.sma.MessageChannel;
 import com.neeve.sma.MessageChannel.Qos;
 import com.neeve.sma.MessageChannel.RawKeyResolutionTable;
-import com.neeve.sma.MessageChannel;
 import com.neeve.sma.MessageChannelDescriptor;
 import com.neeve.sma.SmaException;
 import com.neeve.sma.impl.MessageChannelBase;
@@ -51,14 +51,15 @@ import com.neeve.toa.service.ToaService;
 import com.neeve.toa.service.ToaServiceChannel;
 import com.neeve.toa.spi.AbstractTopicResolver;
 import com.neeve.toa.spi.ChannelFilterProvider;
+import com.neeve.toa.spi.ChannelJoinProvider;
 import com.neeve.toa.spi.ChannelQosProvider;
 import com.neeve.toa.spi.TopicResolver;
 import com.neeve.util.UtlTailoring;
 
 /**
- * 
+ * Tests for channel send and join parsing
  */
-public class ChannelKeysAndFiltersTest extends AbstractToaTest {
+public class ChannelResolutionTest extends AbstractToaTest {
     private static final Properties IKRT = new Properties();
     static {
         //Initialize clean key property (it is static):
@@ -128,6 +129,186 @@ public class ChannelKeysAndFiltersTest extends AbstractToaTest {
         @Override
         public String getChannelFilter(ToaService service, ToaServiceChannel channel) {
             return "IntField=2|4";
+        }
+    }
+
+    @AppHAPolicy(HAPolicy.EventSourcing)
+    public static final class NoJoinJoinProviderReceiverApp extends AbstractToaTestApp {
+        @EventHandler
+        public void onReceiverMessage1(ReceiverMessage1 message) {
+            recordReceipt(message);
+        }
+
+        @EventHandler
+        public void onReceiverMessage2(ReceiverMessage2 message) {
+            recordReceipt(message);
+        }
+
+        @Override
+        public void addChannelJoinProviders(Set<Object> providers) {
+            super.addChannelJoinProviders(providers);
+            providers.add(new ChannelJoinProvider() {
+
+                @Override
+                public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel) {
+                    if (channel.getSimpleName().equals("ReceiverChannel1")) {
+                        return ChannelJoin.NoJoin;
+                    }
+                    return null;
+                }
+            });
+        }
+    }
+
+    @AppHAPolicy(HAPolicy.EventSourcing)
+    public static final class JoinJoinProviderReceiverApp extends AbstractToaTestApp {
+        @EventHandler
+        public void onReceiverMessage1(ReceiverMessage1 message) {
+            recordReceipt(message);
+        }
+
+        @EventHandler
+        public void onReceiverMessage2(ReceiverMessage2 message) {
+            recordReceipt(message);
+        }
+
+        @Override
+        public void addChannelJoinProviders(Set<Object> providers) {
+            super.addChannelJoinProviders(providers);
+
+            // add multiple providers that specify default join behavior for channel 1:
+            providers.add(new ChannelJoinProvider() {
+
+                @Override
+                public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel) {
+                    if (channel.getSimpleName().equals("ReceiverChannel1")) {
+                        return ChannelJoin.Default;
+                    }
+                    return null;
+                }
+            });
+
+            providers.add(new ChannelJoinProvider() {
+
+                @Override
+                public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel) {
+                    if (channel.getSimpleName().equals("ReceiverChannel1")) {
+                        return ChannelJoin.Default;
+                    }
+                    return null;
+                }
+            });
+
+            providers.add(new ChannelJoinProvider() {
+
+                @Override
+                public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel) {
+                    return null;
+                }
+            });
+
+            // add some unrelated providers
+            providers.add(new ChannelJoinProvider() {
+
+                @Override
+                public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel) {
+                    if (channel.getSimpleName().equals("ReceiverChannel3")) {
+                        return ChannelJoin.NoJoin;
+                    }
+                    return null;
+                }
+            });
+
+            providers.add(new ChannelJoinProvider() {
+
+                @Override
+                public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel) {
+                    if (channel.getSimpleName().equals("ReceiverChannel4")) {
+                        return ChannelJoin.Join;
+                    }
+                    return null;
+                }
+            });
+
+            // add unecessary join provider for channel 2:
+            providers.add(new ChannelJoinProvider() {
+
+                @Override
+                public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel) {
+                    if (channel.getSimpleName().equals("ReceiverChannel2")) {
+                        return ChannelJoin.Join;
+                    }
+                    return null;
+                }
+            });
+        }
+    }
+
+    @AppHAPolicy(HAPolicy.EventSourcing)
+    public static final class DefaultJoinProviderReceiverApp extends AbstractToaTestApp {
+
+        @EventHandler
+        public void onReceiverMessage(ReceiverMessage1 message) {
+            recordReceipt(message);
+        }
+
+        @EventHandler
+        public void onReceiverMessage2(ReceiverMessage2 message) {
+            recordReceipt(message);
+        }
+
+        @Override
+        public void addChannelJoinProviders(Set<Object> providers) {
+            super.addChannelJoinProviders(providers);
+            providers.add(new ChannelJoinProvider() {
+
+                @Override
+                public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel) {
+                    if (channel.getSimpleName().equals("ReceiverChannel5")) {
+                        return ChannelJoin.Join;
+                    }
+                    return null;
+                }
+            });
+        }
+    }
+
+    @AppHAPolicy(HAPolicy.EventSourcing)
+    public static final class ConflictingJoinProviderReceiverApp extends AbstractToaTestApp {
+        @EventHandler
+        public void onReceiverMessage1(ReceiverMessage1 message) {
+            recordReceipt(message);
+        }
+
+        @EventHandler
+        public void onReceiverMessage2(ReceiverMessage2 message) {
+            recordReceipt(message);
+        }
+
+        @Override
+        public void addChannelJoinProviders(Set<Object> providers) {
+            super.addChannelJoinProviders(providers);
+            providers.add(new ChannelJoinProvider() {
+
+                @Override
+                public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel) {
+                    if (channel.getSimpleName().equals("ReceiverChannel1")) {
+                        return ChannelJoin.NoJoin;
+                    }
+                    return null;
+                }
+            });
+
+            providers.add(new ChannelJoinProvider() {
+
+                @Override
+                public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel) {
+                    if (channel.getSimpleName().equals("ReceiverChannel1")) {
+                        return ChannelJoin.Join;
+                    }
+                    return null;
+                }
+            });
         }
     }
 
@@ -932,5 +1113,84 @@ public class ChannelKeysAndFiltersTest extends AbstractToaTest {
         sender.sendTestMessage(message);
         assertEquals("Key was not cleaned", "Receiver5/a_b_c", sender.sent.get(0).getMessageKey());
         assertTrue("Receiver didn't receive message", receiver.waitForMessages(10, 1));
+    }
+
+    @Test
+    public void testConflictingJoinProvider() throws Throwable {
+        try {
+            createApp("testConflictingJoinProvider", "standalone", ConflictingJoinProviderReceiverApp.class);
+            fail("Application with conflicting join providers started successfully");
+        }
+        catch (Exception e) {
+            assertTrue("Expected startup failure exception to contain 'Conflicting channel join provided' but was '" + e.getMessage() + "'", e.getMessage().toLowerCase().indexOf("conflicting channel join provided") >= 0);
+        }
+    }
+
+    @Test
+    public void testChannelJoinProviderNoJoin() throws Throwable {
+        NoJoinJoinProviderReceiverApp receiver = createApp("testChannelJoinProviderNoJoin", "standalone", NoJoinJoinProviderReceiverApp.class);
+        receiver.holdMessages = true;
+        SenderApp sender = createApp("sender", "standalone", SenderApp.class);
+
+        sender.sendMessage(ReceiverMessage1.create(), "Receiver1/1");
+        sender.sendMessage(ReceiverMessage2.create(), "Receiver2/1");
+
+        sender.waitForTransactionStability(1);
+        receiver.waitForTransactionStability(1);
+
+        if (verbose()) {
+            for (IRogMessage message : sender.sent) {
+                System.out.println("Sent: " + message.toString());
+            }
+        }
+
+        // receiver should only get ReceiverMessage2 since ReceiverMessage1 channel 
+        // join was set to false
+        receiver.assertExpectedReceipt(5, 1);
+        assertEquals("Wrong type for received message", ReceiverMessage2.class, receiver.received.get(0).getClass());
+    }
+
+    @Test
+    public void testChannelJoinProviderJoin() throws Throwable {
+        JoinJoinProviderReceiverApp receiver = createApp("testChannelJoinProviderNoJoin", "standalone", JoinJoinProviderReceiverApp.class);
+        receiver.holdMessages = true;
+        SenderApp sender = createApp("sender", "standalone", SenderApp.class);
+
+        // send a message on channel 5 for which the app has no EventHandler.
+        // This will result in an AepUnhandledMessageEvent which the app will
+        // treat as a valid receive. 
+        sender.sendMessage(ReceiverMessage5.create(), "Receiver5/1");
+        sender.sendMessage(ReceiverMessage2.create(), "Receiver2/1");
+
+        sender.waitForTransactionStability(1);
+        receiver.waitForTransactionStability(2);
+
+        // receiver should only get ReceiverMessage2 since ReceiverMessage1 channel 
+        // join was set to false
+        receiver.assertExpectedReceipt(5, 2);
+        assertEquals("Wrong type for received message", ReceiverMessage5.class, receiver.received.get(0).getClass());
+        assertEquals("Wrong type for received message", ReceiverMessage2.class, receiver.received.get(1).getClass());
+    }
+
+    @Test
+    public void testChannelJoinProviderDefault() throws Throwable {
+        DefaultJoinProviderReceiverApp receiver = createApp("testChannelJoinProviderNoJoin", "standalone", DefaultJoinProviderReceiverApp.class);
+        receiver.holdMessages = true;
+        SenderApp sender = createApp("sender", "standalone", SenderApp.class);
+
+        // send a message on channel 1 for which the app has no EventHandler.
+        // This will result in an AepUnhandledMessageEvent which the app will
+        // treat as a valid receive. 
+        sender.sendMessage(ReceiverMessage1.create(), "Receiver1/1");
+        sender.sendMessage(ReceiverMessage2.create(), "Receiver2/1");
+
+        sender.waitForTransactionStability(1);
+        receiver.waitForTransactionStability(2);
+
+        // receiver should only get ReceiverMessage2 since ReceiverMessage1 channel 
+        // join was set to false
+        receiver.assertExpectedReceipt(5, 2);
+        assertEquals("Wrong type for received message", ReceiverMessage1.class, receiver.received.get(0).getClass());
+        assertEquals("Wrong type for received message", ReceiverMessage2.class, receiver.received.get(1).getClass());
     }
 }

--- a/nvx-hornet/src/test/java/com/neeve/toa/test/unit/ClusteringTest.java
+++ b/nvx-hornet/src/test/java/com/neeve/toa/test/unit/ClusteringTest.java
@@ -21,8 +21,10 @@
  */
 package com.neeve.toa.test.unit;
 
-import static org.junit.Assert.*;
-import static com.neeve.toa.test.unit.SingleAppToaServer.*;
+import static com.neeve.toa.test.unit.SingleAppToaServer.PROP_NAME_STORE_ENABLED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/nvx-hornet/src/test/java/com/neeve/toa/test/unit/MessageInjectionTest.java
+++ b/nvx-hornet/src/test/java/com/neeve/toa/test/unit/MessageInjectionTest.java
@@ -21,7 +21,11 @@
  */
 package com.neeve.toa.test.unit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;

--- a/nvx-hornet/src/test/java/com/neeve/toa/test/unit/ServiceModelTest.java
+++ b/nvx-hornet/src/test/java/com/neeve/toa/test/unit/ServiceModelTest.java
@@ -21,7 +21,10 @@
  */
 package com.neeve.toa.test.unit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;

--- a/nvx-hornet/src/test/java/com/neeve/toa/test/unit/ToaMessagingTest.java
+++ b/nvx-hornet/src/test/java/com/neeve/toa/test/unit/ToaMessagingTest.java
@@ -9,9 +9,9 @@
  *
  * Neeve Research licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at:
+ * with the License. You may obtain a copy of the License at:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,7 +21,12 @@
  */
 package com.neeve.toa.test.unit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.PrintWriter;
 import java.util.HashMap;
@@ -446,7 +451,7 @@ public class ToaMessagingTest extends AbstractToaTest {
         app.injectMessage(message);
 
         //Note that the app records unhandled and appException messages as received.
-        app.assertExpectedReceipt(2, 1);
+        app.assertExpectedReceipt(5, 1);
 
         assertNull("App should not have received message of type " + ForwarderMessage1.class.getSimpleName(), app.receivedMessage);
 


### PR DESCRIPTION
Implement ability to control channel join for channels associated with
messages with registered message handlers   

Fix Info:
-Adds ChannelJoinProvider interface which can return Default, NoJoin
 or Join to indicate the join behavior for a channel. 
-Organized Imports
-Removed @NonNull annotations from AbstractHK2TopicOrientedApplication
 (Hornet currently supports Java 1.6)
-Renamed ChannelKeysAndFilterTests to ChannelResolutionTest
