### PR TITLE
TOA-92 Allow addition and configuration of channels not mapped by a

### DIFF
--- a/nvx-hornet/src/main/java/com/neeve/toa/spi/AbstractTopicResolver.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/spi/AbstractTopicResolver.java
@@ -9,9 +9,9 @@
  *
  * Neeve Research licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at:
+ * with the License. You may obtain a copy of the License at:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,6 +31,8 @@ import com.neeve.trace.Tracer;
  * A base class for topic resolvers.
  * <p>
  * TopicResolver classes may subclass this class to reduce future api changes impacting compatibility.
+ * 
+ * <i><b>Note</b>Topic Resolvers are currently an experimental feature</i>
  */
 public abstract class AbstractTopicResolver<T extends MessageView> implements TopicResolver<T> {
     final protected static Tracer tracer = RootConfig.ObjectConfig.createTracer(RootConfig.ObjectConfig.get("nv.toa"));

--- a/nvx-hornet/src/main/java/com/neeve/toa/spi/ChannelFilterProvider.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/spi/ChannelFilterProvider.java
@@ -9,9 +9,9 @@
  *
  * Neeve Research licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at:
+ * with the License. You may obtain a copy of the License at:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,23 +21,32 @@
  */
 package com.neeve.toa.spi;
 
+import com.neeve.toa.TopicOrientedApplication;
 import com.neeve.toa.service.ToaService;
 import com.neeve.toa.service.ToaServiceChannel;
 
 /**
  * A {@link ChannelFilterProvider} resolves the channel filter for a 
  * given {@link ToaServiceChannel} channel. 
+ * 
+ * @see TopicOrientedApplication TopicOrientedApplication messaging configuration
  */
 public interface ChannelFilterProvider {
 
     /**
      * Returns the channel filter for the given {@link ToaServiceChannel}.
      * <p>
+     * <h2>ChannelJoinProvider Conflicts</h2>
+     * It is illegal for one {@link ChannelFilterProvider} to return a differnt channel
+     * filter than another provider. The application will fail to 
+     * start in such a case. 
      * 
      * @param service The service that defined the channel.
      * @param channel The channel. 
      * @return The channel filter or <code>null</null> if the provider either doesn't provide the
      * filter for this channel or if the channel should not be filtered. 
+     * 
+     * @see TopicOrientedApplication TopicOrientedApplication messaging configuration
      */
     public String getChannelFilter(ToaService service, ToaServiceChannel channel);
 }

--- a/nvx-hornet/src/main/java/com/neeve/toa/spi/ChannelInitialKeyResolutionTableProvider.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/spi/ChannelInitialKeyResolutionTableProvider.java
@@ -9,9 +9,9 @@
  *
  * Neeve Research licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at:
+ * with the License. You may obtain a copy of the License at:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ package com.neeve.toa.spi;
 
 import java.util.Properties;
 
+import com.neeve.toa.TopicOrientedApplication;
 import com.neeve.toa.service.ToaService;
 import com.neeve.toa.service.ToaServiceChannel;
 
@@ -30,6 +31,8 @@ import com.neeve.toa.service.ToaServiceChannel;
  * Called by a Topic Oriented Application at the time it is configured which allows all or a portion 
  * of a channel's dynamic key parts to be determined statically at configuration time by returning a 
  * initial Key Resolution Table (KRT).
+ * 
+ * @see TopicOrientedApplication TopicOrientedApplication messaging configuration
  */
 public interface ChannelInitialKeyResolutionTableProvider {
 
@@ -69,6 +72,8 @@ public interface ChannelInitialKeyResolutionTableProvider {
      * @param service The service name. 
      * @param channel The channel for which to perform key resolution
      * @return A key resolution table to substitute some or all of the configured channel key.
+     * 
+     * @see TopicOrientedApplication TopicOrientedApplication messaging configuration
      */
     public Properties getInitialChannelKeyResolutionTable(ToaService service, ToaServiceChannel channel);
 }

--- a/nvx-hornet/src/main/java/com/neeve/toa/spi/ChannelJoinProvider.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/spi/ChannelJoinProvider.java
@@ -34,6 +34,8 @@ import com.neeve.toa.service.ToaServiceChannel;
  * finds an {@link EventHandler} for a message type that is mapped to the channel in a 
  * service definition. An application may provide a {@link ChannelJoinProvider} to override 
  * this behavior. 
+ * 
+ * @see TopicOrientedApplication TopicOrientedApplication messaging configuration
  */
 public interface ChannelJoinProvider {
 
@@ -54,6 +56,17 @@ public interface ChannelJoinProvider {
      * defined for a type mapped to the channel, that the channel should not be joined.
      * </ul>
      * 
+     * <p>
+     * Otherwise, if there isn't a handler for the message and no {@link ChannelJoinProvider} returns a
+     * value, but the channel is preconfigured for the application via DDL configuration then the preconfigured
+     * value for join will be used. In summary, the precendence for determining channel join is as follows:
+     * <ul>
+     * <li> ChannelJoinProvider returning non {@link ChannelJoin#Default Default} join value. 
+     * <li> Presence of a handler for a message mapped to the channel in the service
+     * <li> Preconfigured value in configuration DDL for the application
+     * <li> ... if none of the above then default is not to join. 
+     * </ul>
+     * 
      * <h2>ChannelJoinProvider Conflicts</h2>
      * It is illegal for one {@link ChannelJoinProvider} returns {@link ChannelJoin#Join Join} 
      * and another to return {@link ChannelJoin#NoJoin NoJoin}. The application will fail to 
@@ -62,7 +75,8 @@ public interface ChannelJoinProvider {
      * @param service The service that defined the channel.
      * @param channel The channel. 
      * 
-     * @return A value indicating whether or not the channel should be joined. 
+     * @return A value indicating whether or not the channel should be joined.
+     * @see TopicOrientedApplication TopicOrientedApplication messaging configuration 
      */
     public ChannelJoin getChannelJoin(ToaService service, ToaServiceChannel channel);
 }

--- a/nvx-hornet/src/main/java/com/neeve/toa/spi/ChannelQosProvider.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/spi/ChannelQosProvider.java
@@ -48,6 +48,8 @@ import com.neeve.toa.service.ToaServiceChannel;
  * 
  * The above logic only applies to channels discovered in Hornet services. Any preconfigured channels 
  * for a bus that are unrelated to a service for the application are not modified. 
+ * 
+ * @see TopicOrientedApplication TopicOrientedApplication messaging configuration
  */
 public interface ChannelQosProvider {
 
@@ -63,6 +65,8 @@ public interface ChannelQosProvider {
      * 
      * @return The channel {@link Qos} or <code>null</null> if the provider either doesn't provide
      * {@link Qos} for this channel or if the channel should not be filtered. 
+     * 
+     * @see TopicOrientedApplication TopicOrientedApplication messaging configuration
      */
     public Qos getChannelQos(ToaService service, ToaServiceChannel channel);
 }

--- a/nvx-hornet/src/main/java/com/neeve/toa/spi/TopicResolver.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/spi/TopicResolver.java
@@ -9,9 +9,9 @@
  *
  * Neeve Research licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at:
+ * with the License. You may obtain a copy of the License at:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,6 +36,8 @@ import com.neeve.toa.service.ToaServiceChannel;
  * <h2>Threading</h2>
  * TopicResolvers are <b><i>NOT</i></b> and their methods are not safe for
  * concurrent access by multiple threads.
+ * 
+ * <i><b>Note</b>Topic Resolvers are currently an experimental feature</i>
  */
 public interface TopicResolver<T extends MessageView> {
 

--- a/nvx-hornet/src/main/java/com/neeve/toa/spi/TopicResolverProvider.java
+++ b/nvx-hornet/src/main/java/com/neeve/toa/spi/TopicResolverProvider.java
@@ -9,9 +9,9 @@
  *
  * Neeve Research licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at:
+ * with the License. You may obtain a copy of the License at:
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,6 +32,8 @@ import com.neeve.toa.service.ToaServiceChannel;
  * on the channel key defined in the service xml, but in some cases the application can
  * more efficiently resolve the topic, and in such cases may want to provide their own 
  * {@link TopicResolver}s.
+ * 
+ * <i><b>Note</b>Topic Resolvers are currently an experimental feature</i>
  */
 public interface TopicResolverProvider {
 

--- a/nvx-hornet/src/test/resources/services/receiverService.xml
+++ b/nvx-hornet/src/test/resources/services/receiverService.xml
@@ -33,6 +33,8 @@
         <Channel name="ReceiverChannel4" key="Receiver4/${IntField}_${LongField::2}"/>
         <Channel name="ReceiverChannel5" key="Receiver5/${StringField}"/>
         <Channel name="KRTTestChannel" key="KRTTest/${IntField}/${KRTField}"/>
+        <!-- This UnmappedChannel has no messages mapped to it -->
+        <Channel name="UnmappedChannel" key="UnmappedChannel"/>
     </Channels>
     <Roles>
         <To role="Receiver">


### PR DESCRIPTION
message.

Fix Info:
-Changed to process and add channels not mapped by messages to buses
 unless nv.toa.ignoreunmappedchannels=true is specified. 
-Javadoc updates on messaging configuration